### PR TITLE
Initial attempt to integrate runu runtime (uKontainer) with viriot

### DIFF
--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -27,7 +27,7 @@ jobs:
         kubectl apply -f ./yaml/viriot-configmap-setup.yaml
         kubectl apply -f ./yaml/mongo-statefulset-noauth.yaml
         kubectl apply -f ./yaml/vernemq-affinity.yaml
-        sleep 5
+        sleep 15
         kubectl apply -f ./yaml/master-controller.yaml
         sleep 50
         MC_PORT=`kubectl get svc -o wide  |grep master-contro | awk '{print $5}' | cut -d':' -f2 | cut -d'/' -f1`

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        runtime: [""]
+        runtime: ["", "-runu"]
     steps:
     - uses: actions/checkout@master
     - name: pkg install
@@ -14,6 +14,12 @@ jobs:
         sudo apt-get install -y python3-setuptools mosquitto-clients
         sudo pip3 install PyYAML argcomplete
     - uses: engineerd/setup-kind@v0.3.0
+      with:
+          config: "utils/kind-cluster.yaml"
+          image: "thehajime/node-runu:v1.17.0"
+    - name: runtime configuration
+      run: |
+        curl https://raw.githubusercontent.com/ukontainer/runu/master/k8s/ukontainer-runtimeclass.yaml | kubectl apply -f -
     - name: thingvisor setup
       run: |
         MC_ADDR=172.17.0.2
@@ -42,6 +48,7 @@ jobs:
       run: |
         kind export logs logs
         docker exec -i kind-control-plane cat /etc/containerd/config.toml
+        docker exec -i kind-control-plane ip ad |& tee logs/kind-ip-addr.txt
         kubectl logs mongodb-mc-noauth-0 > logs/k8s-mongo.txt
         kubectl logs f4i-master-controller-ss-0
         kubectl logs deployment/f4i-tv-helloworld${{ matrix.runtime }}-helloworld
@@ -50,6 +57,7 @@ jobs:
         kubectl get nodes -o wide |& tee logs/nodes-info.txt
         kubectl get deployment -o wide |& tee logs/deployment-info.txt
         kubectl get svc -o wide |& tee logs/deployment-info.txt
+        kubectl describe runtimeclasses.node.k8s.io |& tee logs/runtime-info.txt
         sudo netstat -anp |& grep tcp > logs/netstat.txt
         ip route |& tee logs/iproute.txt
         ip addr |& tee logs/ipaddr.txt

--- a/Thingvisors/DockerThingVisor/ThingVisor_HelloWorld/Dockerfile.runu
+++ b/Thingvisors/DockerThingVisor/ThingVisor_HelloWorld/Dockerfile.runu
@@ -1,0 +1,16 @@
+# This file is expected to be used via `sh runu/docker-build.sh`
+
+FROM thehajime/runu-python:0.3
+
+COPY thingVisor_hello.py /app/
+COPY context.py /app/
+COPY site-packages/ /usr/lib/python3.5/site-packages/
+
+ENV RUMP_VERBOSE=1
+
+# FIXME: this can be handled by runu itself:
+# users should not configure those internal info.
+COPY runu/kube-resolv.conf /etc/resolv.conf
+
+ENTRYPOINT []
+CMD ["python", "/app/thingVisor_hello.py"]

--- a/Thingvisors/DockerThingVisor/ThingVisor_HelloWorld/runu/docker-build.sh
+++ b/Thingvisors/DockerThingVisor/ThingVisor_HelloWorld/runu/docker-build.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+
+mkdir -p site-packages
+pip3 install pymongo paho-mqtt -t site-packages
+
+cat Dockerfile.runu | sed "s/runu-python:0.3/runu-python:0.3-linux-amd64/" | \
+  docker build -f - -t thehajime/helloworld-tv-runu:1.0-linux-amd64 .
+cat Dockerfile.runu | sed "s/runu-python:0.3/runu-python:0.3-linux-arm64/" | \
+docker build -f - -t thehajime/helloworld-tv-runu:1.0-linux-arm64 .
+cat Dockerfile.runu | sed "s/runu-python:0.3/runu-python:0.3-linux-arm/" | \
+docker build -f - -t thehajime/helloworld-tv-runu:1.0-linux-arm .
+
+docker push thehajime/helloworld-tv-runu:1.0-linux-arm
+docker push thehajime/helloworld-tv-runu:1.0-linux-arm64
+docker push thehajime/helloworld-tv-runu:1.0-linux-amd64
+
+# multi-arch img
+docker manifest create --amend thehajime/helloworld-tv-runu:1.0 \
+	thehajime/helloworld-tv-runu:1.0-linux-arm64 \
+	thehajime/helloworld-tv-runu:1.0-linux-arm \
+	thehajime/helloworld-tv-runu:1.0-linux-amd64
+docker manifest annotate thehajime/helloworld-tv-runu:1.0 \
+	thehajime/helloworld-tv-runu:1.0-linux-arm64 --os linux --arch arm64
+docker manifest annotate thehajime/helloworld-tv-runu:1.0 \
+	thehajime/helloworld-tv-runu:1.0-linux-arm --os linux --arch arm
+docker manifest annotate thehajime/helloworld-tv-runu:1.0 \
+	thehajime/helloworld-tv-runu:1.0-linux-amd64 --os linux --arch amd64
+docker manifest push --purge thehajime/helloworld-tv-runu:1.0
+
+rm -rf site-packages

--- a/Thingvisors/DockerThingVisor/ThingVisor_HelloWorld/runu/kube-resolv.conf
+++ b/Thingvisors/DockerThingVisor/ThingVisor_HelloWorld/runu/kube-resolv.conf
@@ -1,0 +1,3 @@
+search default.svc.cluster.local svc.cluster.local cluster.local
+nameserver 10.96.0.10
+options ndots:5

--- a/Thingvisors/DockerThingVisor/ThingVisor_HelloWorld/runu/lkl.json
+++ b/Thingvisors/DockerThingVisor/ThingVisor_HelloWorld/runu/lkl.json
@@ -1,0 +1,11 @@
+{
+    "interfaces": [
+        {
+            "ip": "AUTO",
+            "name": "eth0",
+            "type": "rumpfd"
+        }
+    ],
+    "debug": "1",
+    "delay_main": "30000"
+}

--- a/utils/kind-cluster.yaml
+++ b/utils/kind-cluster.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runu]
+    runtime_type = "io.containerd.runtime.v1.linux"
+    runtime_engine = "/usr/bin/runu"

--- a/yaml/thingVisor-helloWorld-runu.yaml
+++ b/yaml/thingVisor-helloWorld-runu.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: f4i-tv-helloworld-runu
+spec:
+  selector:
+    matchLabels:
+      app: f4i-helloworld
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: f4i-helloworld
+    spec:
+      runtimeClassName: ukontainer
+      containers:
+      - name: f4i-helloworld-runu
+        image: thehajime/helloworld-tv-runu:1.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
This PR is to introduce how runu runtime is used with viriot framework.

The commits consist of the following parts:
- Dockerfiles and additional files to build runu-specific Docker images
- yaml files (only for Thingvisor Hello for the moment) are added for the k8s integration running runu instead of the default runc runtime.
- additional tests on CI under github actions (only for k8s)

All additions use pre-built docker image located under my private repository (https://hub.docker.com/u/thehajime) but I can move this when an appropriate place is ready to share (e.g., hub.docker.com/fed4iot).

Unfortunately, I needed to modify master-controller.py in order to run under docker environment.  k8s environment doesn't need such framework modification.

~~Since k8s deployment would be main target of this development, I can drop the patch for master-controller.py if it makes noisy.~~

Any comments are welcome.
